### PR TITLE
adding IzzyOnDroid badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gallery for Android
 [![CI](https://github.com/IacobIonut01/Gallery/actions/workflows/androidCompat.yml/badge.svg?branch=v1)](https://github.com/IacobIonut01/Gallery/actions/workflows/androidCompat.yml)
 [![Crowdin](https://badges.crowdin.net/gallery-compose/localized.svg)](https://crowdin.com/project/gallery-compose)
+[![IzzyOnDroid](https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/com.dot.gallery)](https://apt.izzysoft.de/packages/com.dot.gallery/)
 
 ![](./screenshots/preview.png)
 


### PR DESCRIPTION
see #20 – this will add a badge to the first row in the Readme, showing which version of Gallery is currently available at the IzzyOnDroid repo (using the shield.io API, so it automatically updates when a new version becomes available).