### PR TITLE
Add Splash Screen Library

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -191,6 +191,9 @@ dependencies {
     // Subsampling
     implementation(libs.zoomable.image.coil)
 
+    // Splashscreen
+    implementation("androidx.core:core-splashscreen:1.0.1")
+
     // Tests
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,7 +54,7 @@
         <activity
             android:name=".feature_node.presentation.main.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Gallery">
+            android:theme="@style/Theme.Gallery.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/main/MainActivity.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/main/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
@@ -36,6 +37,7 @@ class MainActivity : ComponentActivity() {
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         enforceSecureFlag()

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splashColorBackground">#000000</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="splashColorBackground">#FFFFFF</color>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Gallery" parent="android:Theme.Material.NoActionBar">
+    <style name="Theme.Gallery" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.Gallery" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.Gallery" parent="android:Theme.Material.NoActionBar">
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
+
+    <style name="Theme.Gallery.Splash" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/splashColorBackground</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="postSplashScreenTheme">@style/Theme.Gallery</item>
+    </style>
+
 </resources>
+


### PR DESCRIPTION
This PR adds the androidx Splash Screen compat library, which can be used to show fancy animations when opening the app on API 31+ (Android 12+), and maintains the old behaviour on apis prior to that.

More spefically, I wanted to have different a splash screen when on dark mode, solving https://github.com/IacobIonut01/Gallery/issues/318.

I followed this official guide to migrate to this api: https://developer.android.com/develop/ui/views/launch/splash-screen/migrate.

Tested and working on Pixel 8 (physical) and Pixel 3a (virtual)