### PR TITLE
Fixes #399

### DIFF
--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/media/ZoomablePagerImage.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/media/ZoomablePagerImage.kt
@@ -42,7 +42,7 @@ fun ZoomablePagerImage(
     modifier: Modifier = Modifier,
     media: Media,
     uiEnabled: Boolean,
-    maxScale: Float = 10f,
+    maxScale: Float = 2f,
     onItemClick: () -> Unit
 ) {
     val zoomState = rememberZoomState(


### PR DESCRIPTION
changed `maxScale` to `2f` from `10f`. the excessive zoom issue from double tap gets fixed for now. but, this limited the maximum zoom limit to twice the size. @luca020400 PTAL, should I implement a custom double tap listener in order to fix this?