### PR TITLE
Hide vault button on unsupported systems

### DIFF
--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/library/LibraryScreen.kt
@@ -1,5 +1,6 @@
 package com.dot.gallery.feature_node.presentation.library
 
+import android.os.Build
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -184,17 +185,19 @@ fun LibraryScreen(
                                 Alignment.CenterHorizontally
                             )
                         ) {
-                            LibrarySmallItem(
-                                title = stringResource(R.string.vault),
-                                icon = GalleryIcons.Encrypted,
-                                contentColor = MaterialTheme.colorScheme.secondary,
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .clickable {
-                                        navigate(Screen.VaultScreen())
-                                    },
-                                contentDescription = stringResource(R.string.vault)
-                            )
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                LibrarySmallItem(
+                                    title = stringResource(R.string.vault),
+                                    icon = GalleryIcons.Encrypted,
+                                    contentColor = MaterialTheme.colorScheme.secondary,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .clickable {
+                                            navigate(Screen.VaultScreen())
+                                        },
+                                    contentDescription = stringResource(R.string.vault)
+                                )
+                            }
                             LibrarySmallItem(
                                 title = stringResource(R.string.ignored),
                                 icon = Icons.Outlined.VisibilityOff,


### PR DESCRIPTION
When vault button in library is clicked on android 12 (api 31) app is crashed. This PR hides this button if vault is not supported