### PR TITLE
feat: Add checksum generation results to GitHub release body's text instead of uploading as release artifacts

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,16 +107,16 @@ jobs:
         with:
           name: Gallery Release (Maps)
       - name: Generate SHA256
-        run: find . -name "Gallery-*.apk" -exec bash -c 'sha256sum "$1" | awk '\''{print $1}'\'' > "$1.sha256"' _ {} \;
+        run: echo "### Checksums" >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly-changelog.txt && find . -name "Gallery-*.apk" -type f -print0 | sort -z | xargs -r0 sha256sum | awk '{gsub(/\.\//, ""); print "**"$2"**:", "`"$1"`"} ' >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly-changelog.txt
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }} Nightly Release
+          body_path: ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly-changelog.txt
           prerelease: true
           tag_name: ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly
           files: |
             ./**/Gallery-*.apk
-            ./**/Gallery-*.apk.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           name: Gallery Release (Maps)
       - name: Generate SHA256
-        run: echo "### Checksums" >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly-changelog.txt && find . -name "Gallery-*.apk" -type f -print0 | sort -z | xargs -r0 sha256sum | awk '{gsub(/\.\//, ""); print "**"$2"**:", "`"$1"`"} ' >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly-changelog.txt
+        run: echo "### Checksums" >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly-changelog.txt && find . -name "Gallery-*.apk" -type f -print0 | sort -z | xargs -r0 sha256sum | awk '{gsub(".*/", "", $2); print "**"$2"**:", "`"$1"`"} ' >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly-changelog.txt
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -132,16 +132,16 @@ jobs:
         with:
           name: Gallery Release (Maps)
       - name: Generate SHA256
-        run: find . -name "Gallery-*.apk" -exec bash -c 'sha256sum "$1" | awk '\''{print $1}'\'' > "$1.sha256"' _ {} \;
+        run: echo "### Checksums" >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-changelog.txt && find . -name "Gallery-*.apk" -type f -print0 | sort -z | xargs -r0 sha256sum | awk '{gsub(/\.\//, ""); print "**"$2"**:", "`"$1"`"} ' >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-changelog.txt
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           name: ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }} Release
+          body_path: ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-changelog.txt
           prerelease: false
           tag_name: ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}
           files: |
             ./**/Gallery-*.apk
-            ./**/Gallery-*.apk.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           name: Gallery Release (Maps)
       - name: Generate SHA256
-        run: echo "### Checksums" >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-changelog.txt && find . -name "Gallery-*.apk" -type f -print0 | sort -z | xargs -r0 sha256sum | awk '{gsub(/\.\//, ""); print "**"$2"**:", "`"$1"`"} ' >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-changelog.txt
+        run: echo "### Checksums" >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-changelog.txt && find . -name "Gallery-*.apk" -type f -print0 | sort -z | xargs -r0 sha256sum | awk '{gsub(".*/", "", $2); print "**"$2"**:", "`"$1"`"} ' >> ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-changelog.txt
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/data/data_source/mediastore/queries/AlbumsFlow.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/data/data_source/mediastore/queries/AlbumsFlow.kt
@@ -1,4 +1,4 @@
-package com.dot.gallery.feature_node.data.data_source.mediastore.quries
+package com.dot.gallery.feature_node.data.data_source.mediastore.queries
 
 import android.content.ContentResolver
 import android.content.ContentUris

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/data/data_source/mediastore/queries/MediaFlow.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/data/data_source/mediastore/queries/MediaFlow.kt
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.dot.gallery.feature_node.data.data_source.mediastore.quries
+package com.dot.gallery.feature_node.data.data_source.mediastore.queries
 
 import android.content.ContentResolver
 import android.content.ContentUris
 import android.database.Cursor
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
@@ -27,30 +26,28 @@ import com.dot.gallery.core.util.join
 import com.dot.gallery.feature_node.data.data_source.mediastore.MediaQuery
 import com.dot.gallery.feature_node.domain.model.Media
 import com.dot.gallery.feature_node.domain.model.MediaType
-import com.dot.gallery.feature_node.domain.util.isTrashed
 import com.dot.gallery.feature_node.presentation.util.getDate
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
-import kotlin.random.Random
 
 /**
- * Media uri flow
+ * Media flow
  *
- * This class is responsible for fetching media from the media store based on the provided uris
+ * This class is responsible for fetching media from the media store
  *
  * @property contentResolver
+ * @property buckedId
  * @property mimeType
- * @property uris
- * @property reviewMode
  */
-class MediaUriFlow(
+class MediaFlow(
     private val contentResolver: ContentResolver,
-    private val mimeType: String? = null,
-    private val uris: List<Uri>,
-    private val reviewMode: Boolean = false
+    private val buckedId: Long,
+    private val mimeType: String? = null
 ) : QueryFlow<Media.UriMedia>() {
-
-    private var buckedId: Long = MediaStoreBuckets.MEDIA_STORE_BUCKET_TIMELINE.id
+    init {
+        assert(buckedId != MediaStoreBuckets.MEDIA_STORE_BUCKET_PLACEHOLDER.id) {
+            "MEDIA_STORE_BUCKET_PLACEHOLDER found"
+        }
+    }
 
     override fun flowCursor(): Flow<Cursor?> {
         val uri = MediaQuery.MediaStoreFileUri
@@ -60,7 +57,11 @@ class MediaUriFlow(
                 MediaType.IMAGE -> MediaQuery.Selection.image
                 MediaType.VIDEO -> MediaQuery.Selection.video
             }
-        } ?: MediaQuery.Selection.imageOrVideo
+        } ?: when (buckedId) {
+            MediaStoreBuckets.MEDIA_STORE_BUCKET_PHOTOS.id -> MediaQuery.Selection.image
+            MediaStoreBuckets.MEDIA_STORE_BUCKET_VIDEOS.id -> MediaQuery.Selection.video
+            else -> MediaQuery.Selection.imageOrVideo
+        }
         val albumFilter = when (buckedId) {
             MediaStoreBuckets.MEDIA_STORE_BUCKET_FAVORITES.id -> MediaStore.Files.FileColumns.IS_FAVORITE eq 1
 
@@ -125,68 +126,46 @@ class MediaUriFlow(
         )
     }
 
-    override fun flowData() =
-        flowCursor().mapEachRow(MediaQuery.MediaProjection) { it, indexCache ->
-            var i = 0
+    override fun flowData() = flowCursor().mapEachRow(MediaQuery.MediaProjection) { it, indexCache ->
+        var i = 0
 
-            val id = it.getLong(indexCache[i++])
-            val path = it.getString(indexCache[i++])
-            val relativePath = it.getString(indexCache[i++])
-            val title = it.getString(indexCache[i++])
-            val albumID = it.getLong(indexCache[i++])
-            val albumLabel = it.tryGetString(indexCache[i++], Build.MODEL)
-            val takenTimestamp = it.tryGetLong(indexCache[i++])
-            val modifiedTimestamp = it.getLong(indexCache[i++])
-            val duration = it.tryGetString(indexCache[i++])
-            val size = it.getLong(indexCache[i++])
-            val mimeType = it.getString(indexCache[i++])
-            val isFavorite = it.getInt(indexCache[i++])
-            val isTrashed = it.getInt(indexCache[i++])
-            val expiryTimestamp = it.tryGetLong(indexCache[i])
-            val contentUri = if (mimeType.contains("image"))
-                MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-            else
-                MediaStore.Video.Media.EXTERNAL_CONTENT_URI
-            val uri = ContentUris.withAppendedId(contentUri, id)
-            val formattedDate = modifiedTimestamp.getDate(Constants.FULL_DATE_FORMAT)
-            Media.UriMedia(
-                id = id,
-                label = title,
-                uri = uri,
-                path = path,
-                relativePath = relativePath,
-                albumID = albumID,
-                albumLabel = albumLabel ?: Build.MODEL,
-                timestamp = modifiedTimestamp,
-                takenTimestamp = takenTimestamp,
-                expiryTimestamp = expiryTimestamp,
-                fullDate = formattedDate,
-                duration = duration,
-                favorite = isFavorite,
-                trashed = isTrashed,
-                size = size,
-                mimeType = mimeType
-            )
-        }.let { flow ->
-            val ids = uris.map {
-                try {
-                    ContentUris.parseId(it)
-                } catch (e: NumberFormatException) {
-                    Random.nextInt(1000000, 2000000)
-                }
-            }
-            if (reviewMode) {
-                flow.map { mediaList ->
-                    mediaList.filter { media ->
-                        ids.contains(media.id) && !media.isTrashed
-                    }
-                }
-            } else {
-                flow.map { mediaList ->
-                    mediaList.filter { media ->
-                        ids.contains(media.id)
-                    }
-                }
-            }
-        }
+        val id = it.getLong(indexCache[i++])
+        val path = it.getString(indexCache[i++])
+        val relativePath = it.getString(indexCache[i++])
+        val title = it.getString(indexCache[i++])
+        val albumID = it.getLong(indexCache[i++])
+        val albumLabel = it.tryGetString(indexCache[i++], Build.MODEL)
+        val takenTimestamp = it.tryGetLong(indexCache[i++])
+        val modifiedTimestamp = it.getLong(indexCache[i++])
+        val duration = it.tryGetString(indexCache[i++])
+        val size = it.getLong(indexCache[i++])
+        val mimeType = it.getString(indexCache[i++])
+        val isFavorite = it.getInt(indexCache[i++])
+        val isTrashed = it.getInt(indexCache[i++])
+        val expiryTimestamp = it.tryGetLong(indexCache[i])
+        val contentUri = if (mimeType.contains("image"))
+            MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+        else
+            MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+        val uri = ContentUris.withAppendedId(contentUri, id)
+        val formattedDate = modifiedTimestamp.getDate(Constants.FULL_DATE_FORMAT)
+        Media.UriMedia(
+            id = id,
+            label = title,
+            uri = uri,
+            path = path,
+            relativePath = relativePath,
+            albumID = albumID,
+            albumLabel = albumLabel ?: Build.MODEL,
+            timestamp = modifiedTimestamp,
+            takenTimestamp = takenTimestamp,
+            expiryTimestamp = expiryTimestamp,
+            fullDate = formattedDate,
+            duration = duration,
+            favorite = isFavorite,
+            trashed = isTrashed,
+            size = size,
+            mimeType = mimeType
+        )
+    }
 }

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/data/data_source/mediastore/queries/MediaUriFlow.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/data/data_source/mediastore/queries/MediaUriFlow.kt
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.dot.gallery.feature_node.data.data_source.mediastore.quries
+package com.dot.gallery.feature_node.data.data_source.mediastore.queries
 
 import android.content.ContentResolver
 import android.content.ContentUris
 import android.database.Cursor
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
@@ -26,28 +27,30 @@ import com.dot.gallery.core.util.join
 import com.dot.gallery.feature_node.data.data_source.mediastore.MediaQuery
 import com.dot.gallery.feature_node.domain.model.Media
 import com.dot.gallery.feature_node.domain.model.MediaType
+import com.dot.gallery.feature_node.domain.util.isTrashed
 import com.dot.gallery.feature_node.presentation.util.getDate
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlin.random.Random
 
 /**
- * Media flow
+ * Media uri flow
  *
- * This class is responsible for fetching media from the media store
+ * This class is responsible for fetching media from the media store based on the provided uris
  *
  * @property contentResolver
- * @property buckedId
  * @property mimeType
+ * @property uris
+ * @property reviewMode
  */
-class MediaFlow(
+class MediaUriFlow(
     private val contentResolver: ContentResolver,
-    private val buckedId: Long,
-    private val mimeType: String? = null
+    private val mimeType: String? = null,
+    private val uris: List<Uri>,
+    private val reviewMode: Boolean = false
 ) : QueryFlow<Media.UriMedia>() {
-    init {
-        assert(buckedId != MediaStoreBuckets.MEDIA_STORE_BUCKET_PLACEHOLDER.id) {
-            "MEDIA_STORE_BUCKET_PLACEHOLDER found"
-        }
-    }
+
+    private var buckedId: Long = MediaStoreBuckets.MEDIA_STORE_BUCKET_TIMELINE.id
 
     override fun flowCursor(): Flow<Cursor?> {
         val uri = MediaQuery.MediaStoreFileUri
@@ -57,11 +60,7 @@ class MediaFlow(
                 MediaType.IMAGE -> MediaQuery.Selection.image
                 MediaType.VIDEO -> MediaQuery.Selection.video
             }
-        } ?: when (buckedId) {
-            MediaStoreBuckets.MEDIA_STORE_BUCKET_PHOTOS.id -> MediaQuery.Selection.image
-            MediaStoreBuckets.MEDIA_STORE_BUCKET_VIDEOS.id -> MediaQuery.Selection.video
-            else -> MediaQuery.Selection.imageOrVideo
-        }
+        } ?: MediaQuery.Selection.imageOrVideo
         val albumFilter = when (buckedId) {
             MediaStoreBuckets.MEDIA_STORE_BUCKET_FAVORITES.id -> MediaStore.Files.FileColumns.IS_FAVORITE eq 1
 
@@ -126,46 +125,68 @@ class MediaFlow(
         )
     }
 
-    override fun flowData() = flowCursor().mapEachRow(MediaQuery.MediaProjection) { it, indexCache ->
-        var i = 0
+    override fun flowData() =
+        flowCursor().mapEachRow(MediaQuery.MediaProjection) { it, indexCache ->
+            var i = 0
 
-        val id = it.getLong(indexCache[i++])
-        val path = it.getString(indexCache[i++])
-        val relativePath = it.getString(indexCache[i++])
-        val title = it.getString(indexCache[i++])
-        val albumID = it.getLong(indexCache[i++])
-        val albumLabel = it.tryGetString(indexCache[i++], Build.MODEL)
-        val takenTimestamp = it.tryGetLong(indexCache[i++])
-        val modifiedTimestamp = it.getLong(indexCache[i++])
-        val duration = it.tryGetString(indexCache[i++])
-        val size = it.getLong(indexCache[i++])
-        val mimeType = it.getString(indexCache[i++])
-        val isFavorite = it.getInt(indexCache[i++])
-        val isTrashed = it.getInt(indexCache[i++])
-        val expiryTimestamp = it.tryGetLong(indexCache[i])
-        val contentUri = if (mimeType.contains("image"))
-            MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-        else
-            MediaStore.Video.Media.EXTERNAL_CONTENT_URI
-        val uri = ContentUris.withAppendedId(contentUri, id)
-        val formattedDate = modifiedTimestamp.getDate(Constants.FULL_DATE_FORMAT)
-        Media.UriMedia(
-            id = id,
-            label = title,
-            uri = uri,
-            path = path,
-            relativePath = relativePath,
-            albumID = albumID,
-            albumLabel = albumLabel ?: Build.MODEL,
-            timestamp = modifiedTimestamp,
-            takenTimestamp = takenTimestamp,
-            expiryTimestamp = expiryTimestamp,
-            fullDate = formattedDate,
-            duration = duration,
-            favorite = isFavorite,
-            trashed = isTrashed,
-            size = size,
-            mimeType = mimeType
-        )
-    }
+            val id = it.getLong(indexCache[i++])
+            val path = it.getString(indexCache[i++])
+            val relativePath = it.getString(indexCache[i++])
+            val title = it.getString(indexCache[i++])
+            val albumID = it.getLong(indexCache[i++])
+            val albumLabel = it.tryGetString(indexCache[i++], Build.MODEL)
+            val takenTimestamp = it.tryGetLong(indexCache[i++])
+            val modifiedTimestamp = it.getLong(indexCache[i++])
+            val duration = it.tryGetString(indexCache[i++])
+            val size = it.getLong(indexCache[i++])
+            val mimeType = it.getString(indexCache[i++])
+            val isFavorite = it.getInt(indexCache[i++])
+            val isTrashed = it.getInt(indexCache[i++])
+            val expiryTimestamp = it.tryGetLong(indexCache[i])
+            val contentUri = if (mimeType.contains("image"))
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+            else
+                MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+            val uri = ContentUris.withAppendedId(contentUri, id)
+            val formattedDate = modifiedTimestamp.getDate(Constants.FULL_DATE_FORMAT)
+            Media.UriMedia(
+                id = id,
+                label = title,
+                uri = uri,
+                path = path,
+                relativePath = relativePath,
+                albumID = albumID,
+                albumLabel = albumLabel ?: Build.MODEL,
+                timestamp = modifiedTimestamp,
+                takenTimestamp = takenTimestamp,
+                expiryTimestamp = expiryTimestamp,
+                fullDate = formattedDate,
+                duration = duration,
+                favorite = isFavorite,
+                trashed = isTrashed,
+                size = size,
+                mimeType = mimeType
+            )
+        }.let { flow ->
+            val ids = uris.map {
+                try {
+                    ContentUris.parseId(it)
+                } catch (e: NumberFormatException) {
+                    Random.nextInt(1000000, 2000000)
+                }
+            }
+            if (reviewMode) {
+                flow.map { mediaList ->
+                    mediaList.filter { media ->
+                        ids.contains(media.id) && !media.isTrashed
+                    }
+                }
+            } else {
+                flow.map { mediaList ->
+                    mediaList.filter { media ->
+                        ids.contains(media.id)
+                    }
+                }
+            }
+        }
 }

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/data/data_source/mediastore/queries/QueryFlow.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/data/data_source/mediastore/queries/QueryFlow.kt
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2023 The LineageOS Project
  * SPDX-License-Identifier: Apache-2.0
  */
-package com.dot.gallery.feature_node.data.data_source.mediastore.quries
+package com.dot.gallery.feature_node.data.data_source.mediastore.queries
 
 import android.database.Cursor
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/data/repository/MediaRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/data/repository/MediaRepositoryImpl.kt
@@ -34,9 +34,9 @@ import com.dot.gallery.core.util.ext.updateMediaExif
 import com.dot.gallery.feature_node.data.data_source.InternalDatabase
 import com.dot.gallery.feature_node.data.data_source.KeychainHolder
 import com.dot.gallery.feature_node.data.data_source.KeychainHolder.Companion.VAULT_INFO_FILE_NAME
-import com.dot.gallery.feature_node.data.data_source.mediastore.quries.AlbumsFlow
-import com.dot.gallery.feature_node.data.data_source.mediastore.quries.MediaFlow
-import com.dot.gallery.feature_node.data.data_source.mediastore.quries.MediaUriFlow
+import com.dot.gallery.feature_node.data.data_source.mediastore.queries.AlbumsFlow
+import com.dot.gallery.feature_node.data.data_source.mediastore.queries.MediaFlow
+import com.dot.gallery.feature_node.data.data_source.mediastore.queries.MediaUriFlow
 import com.dot.gallery.feature_node.domain.model.Album
 import com.dot.gallery.feature_node.domain.model.ExifAttributes
 import com.dot.gallery.feature_node.domain.model.IgnoredAlbum


### PR DESCRIPTION
This reduces the amount of uploaded artifacts by half, easing out finding the correct arch and flavour in mobile.
Also fix a small typo in the mediastore queries package.