### PR TITLE
Fix incorrect commit SHA in nightly release git tags

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,6 +116,7 @@ jobs:
           body_path: ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly-changelog.txt
           prerelease: true
           tag_name: ${{ needs.build_maps.outputs.versionName }}-${{ needs.build_maps.outputs.versionCode }}-nightly
+          target_commitish: ${{ github.sha }}
           files: |
             ./**/Gallery-*.apk
         env:


### PR DESCRIPTION
This pull request (hopefully) fixes the issue where the Git tags created by the nightly release CI reference an incorrect commit SHA.

For example, the tag [3.1.2-31208-nightly](https://github.com/IacobIonut01/Gallery/tree/3.1.2-31208-nightly) incorrectly points to 371d8fc instead of db6dc09.