### PR TITLE
Show Filesize of Image in MediaInfo

### DIFF
--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/MediaInfo.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/MediaInfo.kt
@@ -145,32 +145,39 @@ fun Media.retrieveMetadata(
 
         // 8) Image dimensions & megapixels & Image resolution (PPI)
         if (md.imageWidth > 0 && md.imageHeight > 0) {
-            var content = context.getString(
-                R.string.resolution_with_mp,
-                md.imageWidth,
-                md.imageHeight,
-                md.imageMp
-            )
-            if (md.imageResolutionX != null && md.imageResolutionY != null) {
-                val unit = when (md.resolutionUnit) {
-                    2 -> context.getString(R.string.ppi)
-                    3 -> context.getString(R.string.ppcm)
-                    else -> ""
-                }
-                content += context.getString(
-                    R.string.ppi_resolution_string,
-                    md.imageResolutionX,
-                    md.imageResolutionY,
-                    unit
+            val content = buildString {
+                append(
+                    context.getString(
+                        R.string.resolution_with_mp,
+                        md.imageWidth,
+                        md.imageHeight,
+                        md.imageMp
+                    )
                 )
-            }
-            try {
-                val formattedFileSize = File(path).formattedFileSize(context)
-                if (formattedFileSize != "0 ${context.getString(R.string.kb)}") {
-                    content += " • $formattedFileSize"
+                if (md.imageResolutionX != null && md.imageResolutionY != null) {
+                    val unit = when (md.resolutionUnit) {
+                        2 -> context.getString(R.string.ppi)
+                        3 -> context.getString(R.string.ppcm)
+                        else -> ""
+                    }
+                    append(
+                        context.getString(
+                            R.string.ppi_resolution_string,
+                            md.imageResolutionX,
+                            md.imageResolutionY,
+                            unit
+                        )
+                    )
                 }
-            } catch (_: Exception) {
-                // Just for safety, shouldn't crash here
+
+                val formattedFileSize = try {
+                    File(path).formattedFileSize(context)
+                } catch (e: Exception) {
+                    null // Just for safety, shouldn't crash here
+                }
+                if (formattedFileSize != null && formattedFileSize != "0 ${context.getString(R.string.kb)}") {
+                    append(" • $formattedFileSize")
+                }
             }
             info += InfoRow(
                 icon = Icons.Outlined.ImageSearch,
@@ -195,10 +202,12 @@ fun Media.retrieveMetadata(
                     content = "${md.videoWidth} × ${md.videoHeight}"
                 )
             }
-            md.frameRate?.let {
-                var content = context.getString(R.string.video_fps, it)
-                md.bitRate?.let {
-                    content += context.getString(R.string.at_kbps, it.toBitrateString())
+            md.frameRate?.let { fps ->
+                val content = buildString {
+                    append(context.getString(R.string.video_fps, fps))
+                    md.bitRate?.let {
+                        append(context.getString(R.string.at_kbps, it.toBitrateString()))
+                    }
                 }
                 info += InfoRow(
                     icon = Icons.Outlined.Info,

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/MediaInfo.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/MediaInfo.kt
@@ -172,7 +172,7 @@ fun Media.retrieveMetadata(
 
                 val formattedFileSize = try {
                     File(path).formattedFileSize(context)
-                } catch (e: Exception) {
+                } catch (_: Exception) {
                     null // Just for safety, shouldn't crash here
                 }
                 if (formattedFileSize != null && formattedFileSize != "0 ${context.getString(R.string.kb)}") {

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/MediaInfo.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/mediaview/components/MediaInfo.kt
@@ -37,9 +37,11 @@ import com.dot.gallery.feature_node.domain.model.Media
 import com.dot.gallery.feature_node.domain.model.MediaMetadata
 import com.dot.gallery.feature_node.domain.util.isVideo
 import com.dot.gallery.feature_node.presentation.util.formatMinSec
+import com.dot.gallery.feature_node.presentation.util.formattedFileSize
 import com.dot.gallery.feature_node.presentation.util.toBitrateString
 import com.dot.gallery.ui.theme.Shapes
 import kotlinx.coroutines.launch
+import java.io.File
 
 @Composable
 fun MediaInfoRow(
@@ -161,6 +163,14 @@ fun Media.retrieveMetadata(
                     md.imageResolutionY,
                     unit
                 )
+            }
+            try {
+                val formattedFileSize = File(path).formattedFileSize(context)
+                if (formattedFileSize != "0 ${context.getString(R.string.kb)}") {
+                    content += " • $formattedFileSize"
+                }
+            } catch (_: Exception) {
+                // Just for safety, shouldn't crash here
             }
             info += InfoRow(
                 icon = Icons.Outlined.ImageSearch,


### PR DESCRIPTION
Adds the file size back to the Dimensions/Metadata

Also converted the corresponding function to make use of Kotlin `stringBuild` instead of string concatenation

As requested in #664