### PR TITLE
monochrome app icon: increase strokeWidth

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_foreground_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground_monochrome.xml
@@ -7,7 +7,7 @@
     <!-- Outline only -->
     <path
         android:pathData="M42.2,35.9h23.5c4.1,0 7.5,3.3 7.5,7.5V67c0,4.1 -3.4,7.5 -7.5,7.5H42.2c-4.1,0 -7.5,-3.3 -7.5,-7.5V43.4C34.7,39.3 38.1,35.9 42.2,35.9z"
-        android:strokeWidth="2"
+        android:strokeWidth="3"
         android:strokeColor="#000000" />
 
     <!-- Back mountain (filled) -->


### PR DESCRIPTION
Hi, this is a follow-up to #753.

I slightly increased the width of the border / outline to make it more visible on my homescreen and better align with other apps.

## Comparison
| Before | After |
|--------|-------|
| <img width="500" alt="before" src="https://github.com/user-attachments/assets/b337fcde-f5a8-4207-9b2a-ca96271b703d" /> | <img width="500" alt="after" src="https://github.com/user-attachments/assets/07880405-febf-4ba9-a513-9ae33b1eeaca" /> |

