### PR TITLE
Simplify modifier removing redundant `then` that caused a lint error

### DIFF
--- a/libs/cropper/src/main/java/com/smarttoolfactory/cropper/CropModifier.kt
+++ b/libs/cropper/src/main/java/com/smarttoolfactory/cropper/CropModifier.kt
@@ -143,13 +143,11 @@ fun Modifier.crop(
             this.update(cropState)
         }
 
-        this.then(
-            clipToBounds()
-                .then(tapModifier)
-                .then(transformModifier)
-                .then(touchModifier)
-                .then(graphicsModifier)
-        )
+        clipToBounds()
+            .then(tapModifier)
+            .then(transformModifier)
+            .then(touchModifier)
+            .then(graphicsModifier)
     },
     inspectorInfo = debugInspectorInfo {
         name = "crop"


### PR DESCRIPTION
`then` is redundant and causes a linter fail on build. Removed `then` to simplify it and fix the error.