### PR TITLE
fix: request Android 17 local network permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
     <!-- Required to download Map Preview for Media and FCast media serving -->
     <uses-permission android:name="android.permission.INTERNET"/>
 
+    <!-- Android 17+ requires runtime approval for direct connections to LAN addresses. -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK"/>
+
     <!-- Required for FCast device discovery and media streaming -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/app/src/main/kotlin/com/dot/gallery/cloud/ui/CloudAddServerScreen.kt
+++ b/app/src/main/kotlin/com/dot/gallery/cloud/ui/CloudAddServerScreen.kt
@@ -5,6 +5,14 @@
 
 package com.dot.gallery.cloud.ui
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -60,6 +68,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -68,6 +77,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.dot.gallery.R
 import com.dot.gallery.cloud.core.ProviderType
@@ -85,6 +95,10 @@ import com.dot.gallery.feature_node.presentation.util.rememberAppBottomSheetStat
 import dev.chrisbanes.haze.LocalHazeStyle
 import dev.chrisbanes.haze.hazeEffect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.InetAddress
+import java.net.URI
 
 @Composable
 fun CloudAddServerScreen(
@@ -357,6 +371,65 @@ private fun CredentialsStep(
     credentialValues: CredentialValues,
     viewModel: CloudAccountsViewModel
 ) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var showLocalNetworkRationale by remember { mutableStateOf(false) }
+    var pendingConnectionTest by remember { mutableStateOf<(() -> Unit)?>(null) }
+    val localNetworkPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        val action = pendingConnectionTest
+        pendingConnectionTest = null
+        if (granted) action?.invoke()
+    }
+    val testConnection: () -> Unit = {
+        val action = viewModel::testConnection
+        if (Build.VERSION.SDK_INT < 37 || ContextCompat.checkSelfPermission(
+                context, Manifest.permission.ACCESS_LOCAL_NETWORK
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            action()
+        } else {
+            scope.launch {
+                if (isDirectLocalResource(context, state.serverUrl)) {
+                    pendingConnectionTest = action
+                    showLocalNetworkRationale = true
+                } else {
+                    action()
+                }
+            }
+        }
+    }
+
+    if (showLocalNetworkRationale) {
+        AlertDialog(
+            onDismissRequest = {
+                showLocalNetworkRationale = false
+                pendingConnectionTest?.invoke()
+                pendingConnectionTest = null
+            },
+            title = { Text(stringResource(R.string.local_network_permission_dialog_title)) },
+            text = { Text(stringResource(R.string.local_network_permission_dialog_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showLocalNetworkRationale = false
+                    localNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+                }) {
+                    Text(stringResource(R.string.setup_grant_permissions))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showLocalNetworkRationale = false
+                    pendingConnectionTest?.invoke()
+                    pendingConnectionTest = null
+                }) {
+                    Text(stringResource(R.string.local_network_permission_not_now))
+                }
+            }
+        )
+    }
+
     AppTextField(
         value = state.displayName,
         onValueChange = viewModel::updateDisplayName,
@@ -391,7 +464,7 @@ private fun CredentialsStep(
         applyHorizontalPadding = false,
         applyBottomPadding = false,
         applyInsets = false,
-        onClick = viewModel::testConnection
+        onClick = testConnection
     )
     state.testResult?.let { result ->
         Spacer(Modifier.height(8.dp))
@@ -415,6 +488,27 @@ private fun CredentialsStep(
         }
     }
 }
+
+private suspend fun isDirectLocalResource(context: Context, serverUrl: String): Boolean =
+    withContext(Dispatchers.IO) {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE)
+            as? ConnectivityManager
+        val activeCapabilities = connectivityManager?.activeNetwork?.let {
+            connectivityManager.getNetworkCapabilities(it)
+        }
+        if (activeCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true) {
+            return@withContext false
+        }
+
+        val host = runCatching { URI(serverUrl).host }.getOrNull()
+            ?: runCatching { URI("https://$serverUrl").host }.getOrNull()
+            ?: return@withContext false
+        runCatching {
+            InetAddress.getAllByName(host).any {
+                it.isSiteLocalAddress || it.isLoopbackAddress || it.isLinkLocalAddress
+            }
+        }.getOrDefault(false)
+    }
 
 /**
  * Credential input that, for secret fields (password / API key / secrets), renders a trailing

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/cast/FCastSession.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/cast/FCastSession.kt
@@ -120,32 +120,40 @@ class FCastSession @Inject constructor(
     /**
      * Returns a list of all required cast permissions with their current grant status.
      */
-    fun checkPermissions(): List<CastPermission> = listOf(
-        CastPermission(
+    fun checkPermissions(): List<CastPermission> = buildList {
+        add(CastPermission(
             permission = Manifest.permission.INTERNET,
             labelRes = R.string.cast_perm_internet,
             descriptionRes = R.string.cast_perm_internet_desc,
             granted = hasPermission(Manifest.permission.INTERNET)
-        ),
-        CastPermission(
+        ))
+        add(CastPermission(
             permission = Manifest.permission.ACCESS_WIFI_STATE,
             labelRes = R.string.cast_perm_wifi_state,
             descriptionRes = R.string.cast_perm_wifi_state_desc,
             granted = hasPermission(Manifest.permission.ACCESS_WIFI_STATE)
-        ),
-        CastPermission(
+        ))
+        add(CastPermission(
             permission = Manifest.permission.ACCESS_NETWORK_STATE,
             labelRes = R.string.cast_perm_network_state,
             descriptionRes = R.string.cast_perm_network_state_desc,
             granted = hasPermission(Manifest.permission.ACCESS_NETWORK_STATE)
-        ),
-        CastPermission(
+        ))
+        add(CastPermission(
             permission = Manifest.permission.CHANGE_WIFI_MULTICAST_STATE,
             labelRes = R.string.cast_perm_multicast,
             descriptionRes = R.string.cast_perm_multicast_desc,
             granted = hasPermission(Manifest.permission.CHANGE_WIFI_MULTICAST_STATE)
-        ),
-    )
+        ))
+        if (Build.VERSION.SDK_INT >= 37) {
+            add(CastPermission(
+                permission = Manifest.permission.ACCESS_LOCAL_NETWORK,
+                labelRes = R.string.permission_local_network_title,
+                descriptionRes = R.string.setup_reason_local_network,
+                granted = hasPermission(Manifest.permission.ACCESS_LOCAL_NETWORK)
+            ))
+        }
+    }
 
     /**
      * Returns true if all required permissions are granted.

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/cast/components/CastPermissionsDialog.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/cast/components/CastPermissionsDialog.kt
@@ -5,9 +5,13 @@
 
 package com.dot.gallery.feature_node.presentation.cast.components
 
+import android.Manifest
 import android.content.Intent
+import android.os.Build
 import android.net.Uri
 import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -41,6 +45,12 @@ fun CastPermissionsDialog(
     onDismiss: () -> Unit
 ) {
     val context = LocalContext.current
+    val missingLocalNetworkPermission = Build.VERSION.SDK_INT >= 37 && permissions.any {
+        it.permission == Manifest.permission.ACCESS_LOCAL_NETWORK && !it.granted
+    }
+    val localNetworkPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted -> if (granted) onDismiss() }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -71,17 +81,24 @@ fun CastPermissionsDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    context.startActivity(
-                        Intent(
-                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                            Uri.fromParts("package", context.packageName, null)
-                        ).apply {
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        }
-                    )
+                    if (missingLocalNetworkPermission) {
+                        localNetworkPermissionLauncher.launch(Manifest.permission.ACCESS_LOCAL_NETWORK)
+                    } else {
+                        context.startActivity(
+                            Intent(
+                                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                Uri.fromParts("package", context.packageName, null)
+                            ).apply {
+                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            }
+                        )
+                    }
                 }
             ) {
-                Text(stringResource(R.string.cast_open_settings))
+                Text(stringResource(
+                    if (missingLocalNetworkPermission) R.string.setup_grant_permissions
+                    else R.string.cast_open_settings
+                ))
             }
         },
         dismissButton = {

--- a/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/setup/pages/SetupPermissionsPage.kt
+++ b/app/src/main/kotlin/com/dot/gallery/feature_node/presentation/setup/pages/SetupPermissionsPage.kt
@@ -137,9 +137,38 @@ fun SetupPermissionsPage(
                             ) == PackageManager.PERMISSION_GRANTED
                     )
                 }
+                var localNetworkGranted by remember {
+                    mutableStateOf(
+                        Build.VERSION.SDK_INT < 37 ||
+                            ContextCompat.checkSelfPermission(
+                                context, Manifest.permission.ACCESS_LOCAL_NETWORK
+                            ) == PackageManager.PERMISSION_GRANTED
+                    )
+                }
                 RepeatOnResume {
                     isStorageManager = Environment.isExternalStorageManager()
                     canManageMedia = MediaStore.canManageMedia(context)
+                    if (Build.VERSION.SDK_INT >= 37) {
+                        localNetworkGranted = ContextCompat.checkSelfPermission(
+                            context, Manifest.permission.ACCESS_LOCAL_NETWORK
+                        ) == PackageManager.PERMISSION_GRANTED
+                    }
+                }
+
+                if (Build.VERSION.SDK_INT >= 37 && !BuildConfig.OFFLINE_MODE) {
+                    val localNetworkPermission = rememberPermissionState(
+                        permission = Manifest.permission.ACCESS_LOCAL_NETWORK,
+                        onPermissionResult = { localNetworkGranted = it }
+                    )
+                    SetupPermissionItem(
+                        icon = Icons.Rounded.SignalWifi4Bar,
+                        title = stringResource(R.string.permission_local_network_title),
+                        reason = stringResource(R.string.setup_reason_local_network),
+                        optional = true,
+                        granted = localNetworkGranted,
+                        grantActionLabel = stringResource(R.string.setup_grant_permissions),
+                        onGrant = { localNetworkPermission.launchPermissionRequest() }
+                    )
                 }
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1725,6 +1725,11 @@
     <string name="setup_permissions_title">Permissions</string>
     <string name="setup_permissions_subtitle">ReFra only uses what it needs to show and manage your media. Tap a permission to learn why.</string>
     <string name="setup_permission_used_for">Used for:</string>
+    <string name="permission_local_network_title">Direct local network access</string>
+    <string name="setup_reason_local_network">Optional. Grant this only when ReFra connects directly to a server on your current network.</string>
+    <string name="local_network_permission_dialog_title">Allow direct local network access?</string>
+    <string name="local_network_permission_dialog_message">This server resolves to a device on your current local network. Android requires permission before ReFra can connect to it directly.</string>
+<string name="local_network_permission_not_now">Not now</string>
 
     <!-- Permission reasons (where/why) -->
     <string name="setup_reason_read_images"><![CDATA[Displaying your photos in the timeline, albums and viewer. Without this, the gallery stays empty.]]></string>


### PR DESCRIPTION
Android 17 blocks local-network connections for apps targeting SDK 37 unless `ACCESS_LOCAL_NETWORK` is granted. Without it, connecting through a direct private IP or a reverse-proxy domain that resolves to a private IP fails with a connection timeout.

This PR declares the permission, offers it as optional during setup, and requests it later with an explanation when accessing a local server or using FCast. Internet- and VPN-routed connections remain unaffected.

Tested on a Pixel 6 running Android 17 with Immich behind a local reverse proxy.

fixes: https://github.com/IacobIonut01/ReFra/issues/1091